### PR TITLE
Add Gemini portrait to campaign pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -58,7 +58,7 @@
                         <p class="text-lg text-gray-600">Beyond the campaign, Connor spends his weekends coaching youth baseball and volunteering at the local food pantry. He knows our community's strengths because he has been a part of it his entire life.</p>
                     </div>
                     <div class="md:col-span-2 scroll-animate">
-                        <img src="https://placehold.co/500x500/e2e8f0/334155?text=Connor+Oswald" alt="Connor Oswald" class="rounded-lg shadow-2xl w-full">
+                        <img src="Gemini_Generated_Image_z1obtcz1obtcz1ob.png" alt="Portrait of Connor Oswald" class="rounded-lg shadow-2xl w-full object-cover">
                     </div>
                 </div>
                 <div class="mt-12 scroll-animate">

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
                         </p>
                     </div>
                     <div class="md:col-span-2 scroll-animate">
-                         <img src="https://placehold.co/500x500/e2e8f0/334155?text=Connor+Oswald" alt="Connor Oswald" class="rounded-lg shadow-2xl w-full">
+                         <img src="Gemini_Generated_Image_z1obtcz1obtcz1ob.png" alt="Portrait of Connor Oswald" class="rounded-lg shadow-2xl w-full object-cover">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the placeholder hero image on the home page's about section with the Gemini-generated portrait asset
- update the about page to use the same Gemini portrait so the imagery matches across the site

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cadf414588832e977425eb99627f3b